### PR TITLE
Add support for Bitbucket Code Insights

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,14 @@
 
 Coan is a code analysis Maven plugin that runs Checkstyle and PMD and generates a single page HTML report.
 You can either generate an individual report for each module or an aggregated report for all modules in a Maven project.
+
 It also logs the issues it finds to the console with links that are clickable and open the respective file in IntelliJ IDEA.
+
+Coan detects when it is run as part of a GitHub workflow and automatically appends the report to the job's summary.
+
+It also supports GitLab Code Quality reports, which you can attach as an artefact to your GitLab CI/CD job so the issues the plugin found are summarized in merge requests and the pipeline view.
+
+When run as part of a Bitbucket pipeline, the plugin automatically generates a code insight report and attaches the report to the build.
 
 == Usage
 

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -92,5 +92,6 @@
     </module>
     <module name="LineLength">
         <property name="max" value="120"/>
+        <property name="ignorePattern" value="^(package|import| *\* &lt;a) .*"/>
     </module>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,12 @@
       <version>4.1.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>3.13.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
       ${project.build.directory}/site/jacoco/jacoco.xml,
       ${project.build.directory}/site/jacoco-it/jacoco.xml
     </sonar.coverage.jacoco.xmlReportPaths>
+    <!-- AbstractCoanMojo.java is tested by Maven Tests which do record coverage data. -->
+    <sonar.coverage.exclusions>**/AbstractCoanMojo.java</sonar.coverage.exclusions>
   </properties>
 
   <dependencies>
@@ -460,7 +462,6 @@
               </formats>
             </configuration>
           </plugin>
-
         </plugins>
       </build>
     </profile>

--- a/src/main/java/ch/acanda/maven/coan/report/BitBucketReport.java
+++ b/src/main/java/ch/acanda/maven/coan/report/BitBucketReport.java
@@ -1,0 +1,119 @@
+package ch.acanda.maven.coan.report;
+
+import ch.acanda.maven.coan.Inspection;
+import ch.acanda.maven.coan.Issue;
+import ch.acanda.maven.coan.Issue.Severity;
+import ch.acanda.maven.coan.report.bitbucket.Annotation;
+import ch.acanda.maven.coan.report.bitbucket.AnnotationSeverity;
+import ch.acanda.maven.coan.report.bitbucket.Pipeline;
+import ch.acanda.maven.coan.report.bitbucket.Report;
+import ch.acanda.maven.coan.report.bitbucket.ReportApiClient;
+import org.apache.maven.plugin.MojoFailureException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import static ch.acanda.maven.coan.report.bitbucket.Result.FAILED;
+import static ch.acanda.maven.coan.report.bitbucket.Result.PASSED;
+
+/**
+ * Creates a code insights report for BitBucket and publishes it to the
+ * <a href="https://developer.atlassian.com/cloud/bitbucket/rest/api-group-reports/#api-group-reports">BitBucket Reports
+ * API</a>
+ */
+public class BitBucketReport {
+
+    private final Path baseDir;
+    private final List<Inspection> inspections;
+
+    public BitBucketReport(final Path baseDir, final Inspection... inspections) {
+        this.baseDir = baseDir;
+        this.inspections = Arrays.asList(inspections);
+    }
+
+    public void publishToBitBucket(final Pipeline pipeline) throws MojoFailureException {
+        final ReportApiClient client = new ReportApiClient(pipeline);
+        try {
+            client.createOrUpdateReport(createReport());
+            for (final List<Annotation> annotations : createPartitionedAnnotations()) {
+                client.createOrUpdateAnnotations(annotations);
+            }
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new MojoFailureException("Publishing the BitBucket Code Insights report was interrupted", e);
+        } catch (final IOException e) {
+            throw new MojoFailureException("Failed to publish the BitBucket Code Insights report", e);
+        }
+    }
+
+    private Report createReport() {
+        final int numberOfIssues = inspections.stream().mapToInt(Inspection::getNumberOfIssues).sum();
+        final String issues = switch (numberOfIssues) {
+            case 0 -> "no issues";
+            case 1 -> "one issue";
+            default -> numberOfIssues + " issues";
+        };
+        return new Report(
+            "The Code Analysis Maven Plugin found %s.".formatted(issues),
+            numberOfIssues == 0 ? PASSED : FAILED
+        );
+    }
+
+    /**
+     * The BitBucket API only allows a maximum of 100 annotations per request,
+     * so we need to partition the annotations into smaller lists.
+     */
+    private List<List<Annotation>> createPartitionedAnnotations() {
+        final List<Annotation> allAnnotations = inspections.stream().flatMap(inspection ->
+            inspection.issues().stream().map(issue ->
+                createAnnotation(inspection, issue)
+            )
+        ).toList();
+        return partition(allAnnotations, 100);
+    }
+
+    private List<List<Annotation>> partition(final List<Annotation> list, final int size) {
+        final int listSize = list.size();
+        return IntStream.range(0, (listSize + size - 1) / size)
+            .mapToObj(i ->
+                list.subList(
+                    i * size,
+                    Math.min(listSize, (i + 1) * size)
+                )
+            )
+            .toList();
+    }
+
+    private Annotation createAnnotation(final Inspection inspection, final Issue issue) {
+        final String path = getPath(issue.file());
+        final String externalId =
+            "%s:%s:%s:%d:%d".formatted(inspection.toolName(), issue.name(), path, issue.line(), issue.column());
+        return new Annotation(
+            UUID.nameUUIDFromBytes(externalId.getBytes(StandardCharsets.UTF_8)),
+            issue.name(),
+            "[%s] %s".formatted(inspection.toolName(), issue.description()),
+            getSeverity(issue.severity()),
+            path,
+            issue.line()
+        );
+    }
+
+    private AnnotationSeverity getSeverity(final Severity severity) {
+        return switch (severity) {
+            case HIGHEST -> AnnotationSeverity.CRITICAL;
+            case HIGH -> AnnotationSeverity.HIGH;
+            case MEDIUM -> AnnotationSeverity.MEDIUM;
+            case LOW, LOWEST, IGNORE -> AnnotationSeverity.LOW;
+        };
+    }
+
+    private String getPath(final Path path) {
+        return baseDir.relativize(path).toString().replace('\\', '/');
+    }
+
+}

--- a/src/main/java/ch/acanda/maven/coan/report/bitbucket/Annotation.java
+++ b/src/main/java/ch/acanda/maven/coan/report/bitbucket/Annotation.java
@@ -1,0 +1,13 @@
+package ch.acanda.maven.coan.report.bitbucket;
+
+import java.util.UUID;
+
+public record Annotation(
+    UUID externalId,
+    String title,
+    String summary,
+    AnnotationSeverity severity,
+    String path,
+    int line
+) {
+}

--- a/src/main/java/ch/acanda/maven/coan/report/bitbucket/AnnotationSeverity.java
+++ b/src/main/java/ch/acanda/maven/coan/report/bitbucket/AnnotationSeverity.java
@@ -1,0 +1,5 @@
+package ch.acanda.maven.coan.report.bitbucket;
+
+public enum AnnotationSeverity {
+    CRITICAL, HIGH, MEDIUM, LOW
+}

--- a/src/main/java/ch/acanda/maven/coan/report/bitbucket/Pipeline.java
+++ b/src/main/java/ch/acanda/maven/coan/report/bitbucket/Pipeline.java
@@ -1,0 +1,10 @@
+package ch.acanda.maven.coan.report.bitbucket;
+
+public record Pipeline(
+    String repoOwner,
+    String repoSlug,
+    String commit,
+    String apiHost,
+    String apiProxy
+) {
+}

--- a/src/main/java/ch/acanda/maven/coan/report/bitbucket/Report.java
+++ b/src/main/java/ch/acanda/maven/coan/report/bitbucket/Report.java
@@ -1,0 +1,7 @@
+package ch.acanda.maven.coan.report.bitbucket;
+
+public record Report(
+    String details,
+    Result result
+) {
+}

--- a/src/main/java/ch/acanda/maven/coan/report/bitbucket/ReportApiClient.java
+++ b/src/main/java/ch/acanda/maven/coan/report/bitbucket/ReportApiClient.java
@@ -1,0 +1,130 @@
+package ch.acanda.maven.coan.report.bitbucket;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.commons.text.StringEscapeUtils.escapeJson;
+
+public class ReportApiClient {
+
+    private final HttpClient client;
+    private final String reportUrl;
+
+    public ReportApiClient(final Pipeline pipeline) {
+        client = createClient(pipeline);
+        reportUrl = "%s/2.0/repositories/%s/%s/commit/%s/reports/code-analysis-maven-plugin"
+            .formatted(pipeline.apiHost(), pipeline.repoOwner(), pipeline.repoSlug(), pipeline.commit());
+    }
+
+    private static HttpClient createClient(final Pipeline pipeline) {
+        return HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_2)
+            .connectTimeout(Duration.ofSeconds(30))
+            .proxy(getProxy(pipeline.apiProxy()))
+            .build();
+    }
+
+    private static ProxySelector getProxy(final String apiProxy) {
+        if (apiProxy != null) {
+            final String[] proxyParts = apiProxy.split(":");
+            if (proxyParts.length == 2) {
+                final InetSocketAddress proxy = new InetSocketAddress(proxyParts[0], Integer.parseInt(proxyParts[1]));
+                return ProxySelector.of(proxy);
+            } else {
+                throw new IllegalArgumentException(
+                    "Invalid proxy specification, expected \"host:port\" but was \"" + apiProxy + "\""
+                );
+            }
+        }
+        return ProxySelector.getDefault();
+    }
+
+    public void createOrUpdateReport(final Report report) throws IOException, InterruptedException {
+        final String payload =
+            """
+            {
+              "reporter": "Code Analysis Maven Plugin",
+              "report_type": "BUG",
+              "title": "Code Analysis Report",
+              "details": "%s",
+              "result": "%s"
+            }
+            """.formatted(escapeJson(report.details()), report.result());
+        final HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(reportUrl))
+            .timeout(Duration.ofSeconds(30))
+            .header("Content-Type", "application/json")
+            .PUT(HttpRequest.BodyPublishers.ofString(payload))
+            .build();
+
+        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        if (!isOk(response.statusCode())) {
+            throw new IOException(
+                "Failed to publish Bitbucket code insights report. Status code: %s, Response: %s"
+                    .formatted(response.statusCode(), response.body())
+            );
+        }
+    }
+
+    public void createOrUpdateAnnotations(final Collection<Annotation> annotations)
+        throws IOException, InterruptedException {
+        final Collection<String> annotationsPayloads = createAnnotationPayloads(annotations);
+        final String payload =
+            """
+            [
+            %s
+            ]
+            """.formatted(String.join(",\n", annotationsPayloads));
+
+        final HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(reportUrl + "/annotations"))
+            .timeout(Duration.ofSeconds(30))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(payload))
+            .build();
+
+        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        if (!isOk(response.statusCode())) {
+            throw new IOException(
+                "Failed to publish Bitbucket code insights annotations. Status code: %s, Response: %s"
+                    .formatted(response.statusCode(), response.body())
+            );
+        }
+    }
+
+   private List<String> createAnnotationPayloads(final Collection<Annotation> annotations) {
+        return annotations.stream().map(annotation ->
+            """
+            {
+              "external_id": "%s",
+              "title": "%s",
+              "annotation_type": "CODE_SMELL",
+              "summary": "%s",
+              "severity": "%s",
+              "path": "%s",
+              "line": %d
+            }
+            """.formatted(
+                annotation.externalId(),
+                escapeJson(annotation.title()),
+                escapeJson(annotation.summary()),
+                annotation.severity(),
+                escapeJson(annotation.path()),
+                annotation.line()
+            )
+        ).toList();
+    }
+
+    private boolean isOk(final int status) {
+        return status >= 200 && status < 300;
+    }
+
+}

--- a/src/main/java/ch/acanda/maven/coan/report/bitbucket/Result.java
+++ b/src/main/java/ch/acanda/maven/coan/report/bitbucket/Result.java
@@ -1,0 +1,5 @@
+package ch.acanda.maven.coan.report.bitbucket;
+
+public enum Result {
+    PASSED, FAILED
+}

--- a/src/test/java/ch/acanda/maven/coan/AnalyseMojoIT.java
+++ b/src/test/java/ch/acanda/maven/coan/AnalyseMojoIT.java
@@ -1,24 +1,43 @@
 package ch.acanda.maven.coan;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.soebes.itf.extension.assertj.MavenProjectResultAssert;
 import com.soebes.itf.jupiter.extension.MavenGoal;
 import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
 import com.soebes.itf.jupiter.extension.MavenTest;
 import com.soebes.itf.jupiter.extension.SystemProperty;
 import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.File;
 
 import static ch.acanda.maven.coan.VersionsMojoTest.CHECKSTYLE_VERSION_PATTERN;
 import static ch.acanda.maven.coan.VersionsMojoTest.PMD_VERSION_PATTERN;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.soebes.itf.extension.assertj.MavenExecutionResultAssert.assertThat;
 
 @MavenJupiterExtension
+@WireMockTest(httpPort = 29_418)
 public class AnalyseMojoIT {
+
+    @BeforeEach
+    void beforeEach() {
+        WireMock.stubFor(any(anyUrl()).willReturn(ok()));
+    }
 
     @MavenTest
     @MavenGoal("verify")
     @SystemProperty(value = "GITHUB_STEP_SUMMARY", content = "target/summary.md")
+    @SystemProperty(value = "BITBUCKET_REPO_OWNER", content = "acanda")
+    @SystemProperty(value = "BITBUCKET_REPO_SLUG", content = "repo")
+    @SystemProperty(value = "BITBUCKET_COMMIT", content = "bfc4fef9")
     public void analyseSucceedsWithoutIssues(final MavenExecutionResult project) {
         final MavenProjectResultAssert target = assertThat(project).isSuccessful().project().hasTarget();
         target.withFile("code-analysis/report.html").exists();
@@ -33,11 +52,17 @@ public class AnalyseMojoIT {
             .anyMatch(line -> line.matches(CHECKSTYLE_VERSION_PATTERN));
         assertThat(project).out().info().contains("PMD did not find any issues in analyse.");
         assertThat(project).out().info().contains("Checkstyle did not find any issues in analyse.");
+        verify(putRequestedFor(
+            urlEqualTo("/2.0/repositories/acanda/repo/commit/bfc4fef9/reports/code-analysis-maven-plugin")
+        ));
     }
 
     @MavenTest
     @MavenGoal("verify")
     @SystemProperty(value = "GITHUB_STEP_SUMMARY", content = "target/summary.md")
+    @SystemProperty(value = "BITBUCKET_REPO_OWNER", content = "acanda")
+    @SystemProperty(value = "BITBUCKET_REPO_SLUG", content = "repo")
+    @SystemProperty(value = "BITBUCKET_COMMIT", content = "bfc4fef9")
     public void analyseFailsWithIssues(final MavenExecutionResult project) {
         final MavenProjectResultAssert target = assertThat(project).isFailure().project().hasTarget();
         target.withFile("code-analysis/report.html").exists();
@@ -61,6 +86,12 @@ public class AnalyseMojoIT {
             " [LineLengthCheck] Line is longer than 35 characters, found 51. (Hello.java:2)",
             " [LineLengthCheck] Line is longer than 35 characters, found 36. (Hello.java:3)"
         );
+        verify(putRequestedFor(
+            urlEqualTo("/2.0/repositories/acanda/repo/commit/bfc4fef9/reports/code-analysis-maven-plugin")
+        ));
+        verify(postRequestedFor(
+            urlEqualTo("/2.0/repositories/acanda/repo/commit/bfc4fef9/reports/code-analysis-maven-plugin/annotations")
+        ));
     }
 
     private static String getPathForJavaSource(final String filename) {

--- a/src/test/java/ch/acanda/maven/coan/report/BitbucketReportTest.java
+++ b/src/test/java/ch/acanda/maven/coan/report/BitbucketReportTest.java
@@ -1,0 +1,195 @@
+package ch.acanda.maven.coan.report;
+
+import ch.acanda.maven.coan.Inspection;
+import ch.acanda.maven.coan.Issue;
+import ch.acanda.maven.coan.report.bitbucket.Pipeline;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
+/**
+ * Test for the BitBucketReport class.
+ * This test verifies that the report makes the REST requests to the BitBucket API.
+ */
+class BitbucketReportTest {
+
+    private static final boolean IGNORE_ARRAY_ORDER = true;
+    private static final boolean FAIL_ON_EXTRA_ELEMENTS = false;
+
+    private static final String WORKSPACE = "acanda";
+    private static final String REPO_SLUG = "repo";
+    private static final String COMMIT = "1234abcd";
+    private static final String REPORT_ID = "code-analysis-maven-plugin";
+    private static final String REPORTS_PATH =
+        "/2.0/repositories/%s/%s/commit/%s/reports/%s".formatted(WORKSPACE, REPO_SLUG, COMMIT, REPORT_ID);
+    private static final String ANNOTATIONS_PATH = REPORTS_PATH + "/annotations";
+
+    @Test
+    void testPublishToBitbucket(@TempDir final Path tempDir) throws MojoFailureException {
+        final WireMockServer server = startMockServer();
+        try {
+
+            final Path baseDir = tempDir.resolve("baseDir");
+            final Path javaMain = baseDir.resolve("src").resolve("main").resolve("java");
+            final Path hello = javaMain.resolve("Hello.java");
+            final Path world = javaMain.resolve("World.java");
+
+            final BitBucketReport report = new BitBucketReport(baseDir,
+                inspection("ABC", List.of(
+                    issue(hello, 12, "IssueA", "Issue A description", Issue.Severity.HIGHEST),
+                    issue(world, 25, "IssueB", "Issue B description", Issue.Severity.HIGH),
+                    issue(hello, 7, "IssueC", "Issue C description", Issue.Severity.MEDIUM),
+                    issue(world, 38, "IssueD", "Issue D description", Issue.Severity.LOW),
+                    issue(hello, 24, "IssueE", "Issue E description", Issue.Severity.LOWEST),
+                    issue(world, 15, "IssueF", "Issue F description", Issue.Severity.IGNORE)
+                ))
+            );
+
+            report.publishToBitBucket(createPipeline(server));
+
+            // Verify the report request
+            verify(putRequestedFor(urlPathMatching(REPORTS_PATH))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(equalToJson(
+                    """
+                    {
+                      "reporter" : "Code Analysis Maven Plugin",
+                      "report_type" : "BUG",
+                      "title" : "Code Analysis Report",
+                      "details" : "The Code Analysis Maven Plugin found 6 issues.",
+                      "result" : "FAILED"
+                    }
+                    """
+                )));
+
+            // Verify the annotations request
+            verify(postRequestedFor(urlPathMatching(ANNOTATIONS_PATH))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(equalToJson(
+                    """
+                    [ {
+                      "external_id" : "b10e88c3-8dc0-3fb1-a543-2e58a98ea8ba",
+                      "title" : "IssueA",
+                      "annotation_type" : "CODE_SMELL",
+                      "summary" : "[ABC] Issue A description",
+                      "severity" : "CRITICAL",
+                      "path" : "src/main/java/Hello.java",
+                      "line" : 12
+                    }, {
+                      "external_id" : "3ceab010-dbc7-3996-bd22-482072ec5b7a",
+                      "title" : "IssueB",
+                      "annotation_type" : "CODE_SMELL",
+                      "summary" : "[ABC] Issue B description",
+                      "severity" : "HIGH",
+                      "path" : "src/main/java/World.java",
+                      "line" : 25
+                    }, {
+                      "external_id" : "309c8925-3b57-37d2-afb2-cfd47115787e",
+                      "title" : "IssueC",
+                      "annotation_type" : "CODE_SMELL",
+                      "summary" : "[ABC] Issue C description",
+                      "severity" : "MEDIUM",
+                      "path" : "src/main/java/Hello.java",
+                      "line" : 7
+                    }, {
+                      "external_id" : "ff5d0a21-d405-303f-8c01-25623320146c",
+                      "title" : "IssueD",
+                      "annotation_type" : "CODE_SMELL",
+                      "summary" : "[ABC] Issue D description",
+                      "severity" : "LOW",
+                      "path" : "src/main/java/World.java",
+                      "line" : 38
+                    }, {
+                      "external_id" : "6ef4efda-1c36-397c-9da3-6e079cc3e9be",
+                      "title" : "IssueE",
+                      "annotation_type" : "CODE_SMELL",
+                      "summary" : "[ABC] Issue E description",
+                      "severity" : "LOW",
+                      "path" : "src/main/java/Hello.java",
+                      "line" : 24
+                    }, {
+                      "external_id" : "29075bcf-a655-3e93-87b7-1ff48b4f57c0",
+                      "title" : "IssueF",
+                      "annotation_type" : "CODE_SMELL",
+                      "summary" : "[ABC] Issue F description",
+                      "severity" : "LOW",
+                      "path" : "src/main/java/World.java",
+                      "line" : 15
+                    } ]
+                    """,
+                    IGNORE_ARRAY_ORDER,
+                    FAIL_ON_EXTRA_ELEMENTS
+                )));
+
+            server.checkForUnmatchedRequests();
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    void shouldChunkAnnotationsWhenMoreThan100Issues(@TempDir final Path tempDir) throws Exception {
+        final WireMockServer server = startMockServer();
+        try {
+            final List<Issue> issues = IntStream.range(0, 150)
+                .mapToObj(i -> issue(tempDir.resolve("A.java"), i, "N", "D", Issue.Severity.MEDIUM))
+                .toList();
+            final BitBucketReport report = new BitBucketReport(tempDir, inspection("ABC", issues));
+            report.publishToBitBucket(createPipeline(server));
+
+            // Verify that createOrUpdateAnnotations() was called twice,
+            // once with 100 annotations and once with 50 annotations.
+            verify(postRequestedFor(urlPathMatching(ANNOTATIONS_PATH))
+                .withRequestBody(matchingJsonPath("$.length()", equalTo("100"))));
+
+            verify(postRequestedFor(urlPathMatching(ANNOTATIONS_PATH))
+                .withRequestBody(matchingJsonPath("$.length()", equalTo("50"))));
+
+            server.checkForUnmatchedRequests();
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static WireMockServer startMockServer() {
+        final WireMockServer server = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        server.start();
+        WireMock.configureFor("localhost", server.port());
+        server.stubFor(put(REPORTS_PATH).willReturn(aResponse().withStatus(200)));
+        server.stubFor(post(ANNOTATIONS_PATH).willReturn(aResponse().withStatus(200)));
+        return server;
+    }
+
+    private static Pipeline createPipeline(final WireMockServer server) {
+        return new Pipeline(WORKSPACE, REPO_SLUG, COMMIT, "http://localhost:" + server.port(), null);
+    }
+
+    private static Inspection inspection(final String tool, final List<? extends Issue> issues) {
+        return new StubInspection(tool, issues, new MavenProject());
+    }
+
+    private static Issue issue(final Path file, final int line, final String name, final String description,
+        final Issue.Severity severity) {
+        return new StubIssue(file, line, 0, name, description, severity);
+    }
+
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publish code-analysis reports and annotations to Bitbucket Code Insights; auto-detect Bitbucket CI and publish when configured.
* **Bug Fixes**
  * More reliable retrieval of configuration from environment and system properties (improves CI integrations).
* **Documentation**
  * Updated docs describing GitHub, GitLab, and Bitbucket reporting behavior and supported formats.
* **Style**
  * Checkstyle updated to ignore line-length for specific patterns.
* **Tests**
  * Added tests verifying report/annotation submission, chunking behavior, and mocked Bitbucket interactions.
* **Chores**
  * Added WireMock test dependency; excluded a file from Sonar coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->