### PR TITLE
Update to Java 21

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           show-progress: false
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - name: Cache OWASP database

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -12,10 +12,10 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           show-progress: false
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - name: Cache SonarCloud packages

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <url>https://github.com/acanda/code-analysis-maven-plugin</url>
 
   <properties>
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.version>3.9.11</maven.version>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Raised project Java baseline to JDK 21. Building and running now require JDK 21.
  * Updated CI workflows to use JDK 21 for builds and Sonar analysis, keeping other steps unchanged.
  * No functional or API changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->